### PR TITLE
chore: Fix ghcr.io deploy error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,11 +44,11 @@ jobs:
         run: |
           TIMESTAMP=$(date '+%Y%m%dT%H%M')
           # ghcr.io
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login https://docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin > /dev/null 2>&1
-          docker tag $DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME ghcr.io/$GITHUB_ACTOR/$DOCKER_IMAGENAME:$DOCKER_TAGNAME
-          docker tag $DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME ghcr.io/$GITHUB_ACTOR/$DOCKER_IMAGENAME:$DOCKER_TAGNAME-$TIMESTAMP
-          docker push ghcr.io/$GITHUB_ACTOR/$DOCKER_IMAGENAME:$DOCKER_TAGNAME
-          docker push ghcr.io/$GITHUB_ACTOR/$DOCKER_IMAGENAME/$DOCKER_TAGNAME:$TIMESTAMP
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login https://docker.pkg.github.com -u $DOCKER_USERNAME --password-stdin > /dev/null 2>&1
+          docker tag $DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME ghcr.io/$DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME
+          docker tag $DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME ghcr.io/$DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME-$TIMESTAMP
+          docker push ghcr.io/$DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME
+          docker push ghcr.io/$DOCKER_USERNAME/$DOCKER_IMAGENAME/$DOCKER_TAGNAME:$TIMESTAMP
           # docker.io
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u "$DOCKER_USERNAME" --password-stdin > /dev/null 2>&1
           docker push $DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME


### PR DESCRIPTION
https://github.com/Tiryoh/docker-ros2-desktop-vnc/runs/1077862423
```
Error parsing reference: "ghcr.io/Tiryoh/ros2-desktop-vnc:eloquent" is not a valid repository/tag: invalid reference format: repository name must be lowercase
##[error]Process completed with exit code 1.
```