### PR TITLE
feat: Drop support for ROS Eloquent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
     if: contains(github.event.head_commit.message, '[skip ci]') == false
     strategy:
       matrix:
-        ros-distro: [dashing, eloquent, foxy]
+        ros-distro: [dashing, foxy]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ros-distro: [dashing, eloquent, foxy]
+        ros-distro: [dashing, foxy]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
ROS Eloquent is no longer supported (EOL Nov. 2020).  
https://index.ros.org/doc/ros2/Releases/  
https://www.ros.org/reps/rep-2000.html#eloquent-elusor-november-2019-november-2020

related: https://github.com/Tiryoh/ros2_setup_scripts_ubuntu/pull/17