### PR TITLE
feat: Update GPG key installation step to the latest

### DIFF
--- a/dashing/ros-dashing-desktop.sh
+++ b/dashing/ros-dashing-desktop.sh
@@ -12,8 +12,8 @@ INSTALL_PACKAGE=desktop
 
 sudo apt-get update
 sudo apt-get install -y curl gnupg2 lsb-release
-curl -Ls https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo apt-key add -
-sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 sudo apt-get update
 sudo apt-get install -y ros-${CHOOSE_ROS_DISTRO}-${INSTALL_PACKAGE}
 sudo apt-get install -y python3-argcomplete

--- a/foxy-arm64/ros-foxy-desktop.sh
+++ b/foxy-arm64/ros-foxy-desktop.sh
@@ -12,8 +12,8 @@ INSTALL_PACKAGE=desktop
 
 sudo apt-get update
 sudo apt-get install -y curl gnupg2 lsb-release
-curl -Ls https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo apt-key add -
-sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 sudo apt-get update
 sudo apt-get install -y ros-${CHOOSE_ROS_DISTRO}-${INSTALL_PACKAGE}
 sudo apt-get install -y python3-argcomplete

--- a/foxy/ros-foxy-desktop.sh
+++ b/foxy/ros-foxy-desktop.sh
@@ -12,8 +12,8 @@ INSTALL_PACKAGE=desktop
 
 sudo apt-get update
 sudo apt-get install -y curl gnupg2 lsb-release
-curl -Ls https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo apt-key add -
-sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 sudo apt-get update
 sudo apt-get install -y ros-${CHOOSE_ROS_DISTRO}-${INSTALL_PACKAGE}
 sudo apt-get install -y python3-argcomplete


### PR DESCRIPTION
same as https://github.com/Tiryoh/ros2_setup_scripts_ubuntu/pull/23