### PR TITLE
ci: Use self-hosted runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         ros-distro: [foxy, galactic, humble, rolling]
         arch: [arm64, amd64]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         ros-distro: [foxy, galactic, humble, rolling]
         arch: [arm64, amd64]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
CI runs are failing frequently while apt-get.

<img width="1041" alt="スクリーンショット 2022-10-29 15 12 51" src="https://user-images.githubusercontent.com/3256629/198816893-24f28f8e-9752-4679-975b-f8a167991e5d.png">
<img width="1066" alt="スクリーンショット 2022-10-29 15 11 48" src="https://user-images.githubusercontent.com/3256629/198816883-5af19d83-8ac7-41a6-86f1-263e71d1c777.png">
<img width="1368" alt="スクリーンショット 2022-10-29 15 12 41" src="https://user-images.githubusercontent.com/3256629/198816888-fdd9f652-86e1-40aa-87e9-26a00ac181c0.png">
