### PR TITLE
fix: Add "--security-opt"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
       - master
     paths:
       - "**/Dockerfile"
-      - "**/ros**.sh"
+      - "**/entrypoint.sh"
       - ".github/workflows/deploy.yml"
   schedule:
     - cron: "7 4 * * 0" # Weekly on Sundays at 13:07 (JST)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
       - master
     paths:
       - "**/Dockerfile"
-      - "**/ros**.sh"
+      - "**/entrypoint.sh"
       - ".github/workflows/test.yml"
   schedule:
     - cron: "0 2 * * 0" # Weekly on Sundays at 02:00

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ https://memoteki.net/archives/2955
 Run the docker container and access with port `6080`.  
 Change the `shm-size` value depending on the situation.
 
+__NOTE__: `--security-opt seccomp=unconfined` flag is required to launch humble image. See https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56.
+
 ```
-docker run -p 6080:80 --shm-size=512m tiryoh/ros2-desktop-vnc:humble
+docker run -p 6080:80 --security-opt seccomp=unconfined --shm-size=512m tiryoh/ros2-desktop-vnc:humble
 ```
 
 Browse http://127.0.0.1:6080/.

--- a/humble/entrypoint.sh
+++ b/humble/entrypoint.sh
@@ -76,4 +76,9 @@ chown -R $USER:$USER $HOME/.ros
 PASSWORD=
 VNC_PASSWORD=
 
+echo "============================================================================================"
+echo "NOTE: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "============================================================================================"
+
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf

--- a/iron/entrypoint.sh
+++ b/iron/entrypoint.sh
@@ -76,4 +76,9 @@ chown -R $USER:$USER $HOME/.ros
 PASSWORD=
 VNC_PASSWORD=
 
+echo "============================================================================================"
+echo "NOTE: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "============================================================================================"
+
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf

--- a/rolling/entrypoint.sh
+++ b/rolling/entrypoint.sh
@@ -76,4 +76,9 @@ chown -R $USER:$USER $HOME/.ros
 PASSWORD=
 VNC_PASSWORD=
 
+echo "============================================================================================"
+echo "NOTE: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "============================================================================================"
+
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
VNC blackouts without "--security-opt" option on Ubuntu

```diff
-docker run -p 6080:80 --shm-size=512m tiryoh/ros2-desktop-vnc:humble
+docker run -p 6080:80 --security-opt seccomp=unconfined --shm-size=512m tiryoh/ros2-desktop-vnc:humble
```

before
![image](https://github.com/Tiryoh/docker-ros2-desktop-vnc/assets/3256629/85ff83a3-301c-4488-a3d7-9e40a44fb5f9)

after
![image](https://github.com/Tiryoh/docker-ros2-desktop-vnc/assets/3256629/ca143f25-ea31-4766-af7f-392a86c142b1)


* related issues
  * https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56
  * https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/85