### PR TITLE
move `RUN rm docker-clean` command to diet image size

### DIFF
--- a/foxy/Dockerfile
+++ b/foxy/Dockerfile
@@ -60,9 +60,6 @@ RUN sed -i "s/UI.initSetting('resize', 'off');/UI.initSetting('resize', 'remote'
 RUN sed -i 's/Prompt=.*/Prompt=never/' /etc/update-manager/release-upgrades
 RUN sed -i 's/enabled=1/enabled=0/g' /etc/default/apport
 
-# Enable apt-get completion
-RUN rm /etc/apt/apt.conf.d/docker-clean
-
 # Install Firefox
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:mozillateam/ppa -y && \
     echo 'Package: *' > /etc/apt/preferences.d/mozilla-firefox && \
@@ -110,6 +107,9 @@ RUN apt-get update -q && \
     ros-${ROS_DISTRO}-gazebo-ros-pkgs \
     ros-${ROS_DISTRO}-ros-ign-gazebo && \
     rm -rf /var/lib/apt/lists/*
+
+# Enable apt-get completion after running `apt-get update` in the container
+RUN rm /etc/apt/apt.conf.d/docker-clean
 
 COPY ./entrypoint.sh /
 ENTRYPOINT [ "/bin/bash", "-c", "/entrypoint.sh" ]

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -61,9 +61,6 @@ RUN sed -i "s/UI.initSetting('resize', 'off');/UI.initSetting('resize', 'remote'
 RUN sed -i 's/Prompt=.*/Prompt=never/' /etc/update-manager/release-upgrades
 RUN sed -i 's/enabled=1/enabled=0/g' /etc/default/apport
 
-# Enable apt-get completion
-RUN rm /etc/apt/apt.conf.d/docker-clean
-
 # Install Firefox
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:mozillateam/ppa -y && \
     echo 'Package: *' > /etc/apt/preferences.d/mozilla-firefox && \
@@ -116,6 +113,9 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
     ros-${ROS_DISTRO}-ros-ign && \
     rm -rf /var/lib/apt/lists/*; \
     fi
+
+# Enable apt-get completion after running `apt-get update` in the container
+RUN rm /etc/apt/apt.conf.d/docker-clean
 
 COPY ./entrypoint.sh /
 RUN dos2unix /entrypoint.sh

--- a/iron/Dockerfile
+++ b/iron/Dockerfile
@@ -61,9 +61,6 @@ RUN sed -i "s/UI.initSetting('resize', 'off');/UI.initSetting('resize', 'remote'
 RUN sed -i 's/Prompt=.*/Prompt=never/' /etc/update-manager/release-upgrades
 RUN sed -i 's/enabled=1/enabled=0/g' /etc/default/apport
 
-# Enable apt-get completion
-RUN rm /etc/apt/apt.conf.d/docker-clean
-
 # Install Firefox
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:mozillateam/ppa -y && \
     echo 'Package: *' > /etc/apt/preferences.d/mozilla-firefox && \
@@ -116,6 +113,9 @@ RUN rosdep update
 #     ros-${ROS_DISTRO}-ros-gz && \
 #     rm -rf /var/lib/apt/lists/*; \
 #     fi
+
+# Enable apt-get completion after running `apt-get update` in the container
+RUN rm /etc/apt/apt.conf.d/docker-clean
 
 COPY ./entrypoint.sh /
 ENTRYPOINT [ "/bin/bash", "-c", "/entrypoint.sh" ]

--- a/rolling/Dockerfile
+++ b/rolling/Dockerfile
@@ -61,9 +61,6 @@ RUN sed -i "s/UI.initSetting('resize', 'off');/UI.initSetting('resize', 'remote'
 RUN sed -i 's/Prompt=.*/Prompt=never/' /etc/update-manager/release-upgrades
 RUN sed -i 's/enabled=1/enabled=0/g' /etc/default/apport
 
-# Enable apt-get completion
-RUN rm /etc/apt/apt.conf.d/docker-clean
-
 # Install Firefox
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:mozillateam/ppa -y && \
     echo 'Package: *' > /etc/apt/preferences.d/mozilla-firefox && \
@@ -116,6 +113,9 @@ RUN rosdep update
 #     ros-${ROS_DISTRO}-ros-gz && \
 #     rm -rf /var/lib/apt/lists/*; \
 #     fi
+
+# Enable apt-get completion after running `apt-get update` in the container
+RUN rm /etc/apt/apt.conf.d/docker-clean
 
 COPY ./entrypoint.sh /
 ENTRYPOINT [ "/bin/bash", "-c", "/entrypoint.sh" ]


### PR DESCRIPTION
This commit can reduce the size of docker images (7.28 GB to 6.33 GB for humble) while keeping apt-get completion feature by moving `RUN rm /etc/apt/apt.conf.d/docker-clean` to the later stage of Dockerfile.

We can close https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/152 when this commit will be merged as PR.

relate:
https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/152#issuecomment-2041350516 https://askubuntu.com/questions/86375/apt-get-autocompletion-of-package-name-is-broken