### PR TITLE
feat: Update console message to guide "docker commit"

### DIFF
--- a/humble/entrypoint.sh
+++ b/humble/entrypoint.sh
@@ -343,8 +343,10 @@ PASSWORD=
 VNC_PASSWORD=
 
 echo "============================================================================================"
-echo "NOTE: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
+echo "NOTE 1: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
 echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "NOTE 2: Before stopping to commit docker container to new docker image, log out first."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e]8;;\e\\'
 echo "============================================================================================"
 
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf

--- a/iron/entrypoint.sh
+++ b/iron/entrypoint.sh
@@ -343,8 +343,10 @@ PASSWORD=
 VNC_PASSWORD=
 
 echo "============================================================================================"
-echo "NOTE: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
+echo "NOTE 1: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
 echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "NOTE 2: Before stopping to commit docker container to new docker image, log out first."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e]8;;\e\\'
 echo "============================================================================================"
 
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf

--- a/rolling/entrypoint.sh
+++ b/rolling/entrypoint.sh
@@ -343,8 +343,10 @@ PASSWORD=
 VNC_PASSWORD=
 
 echo "============================================================================================"
-echo "NOTE: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
+echo "NOTE 1: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
 echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "NOTE 2: Before stopping to commit docker container to new docker image, log out first."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e]8;;\e\\'
 echo "============================================================================================"
 
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION

> I made the earlier suggestion with the thought that a message on the console when "docker run" might tell the user that they need to log out before stopping to commit the docker container to a new docker image.
> 
> I am thinking of adding "docker commit instructions" to the README as well as the console message above until the issue is resolved.
> 
> ![image](https://github.com/Tiryoh/docker-ros2-desktop-vnc/assets/3256629/e5172fb2-46b6-4b14-a160-98f2955dfcbb)

_Originally posted by @Tiryoh in https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/131#issuecomment-2002516191_
            