### PR TITLE
fix: Add workaround for issue when image is created with "docker commit"

### DIFF
--- a/foxy/entrypoint.sh
+++ b/foxy/entrypoint.sh
@@ -42,6 +42,17 @@ VNCRUN_PATH=$HOME/.vnc/vnc_run.sh
 cat << EOF > $VNCRUN_PATH
 #!/bin/sh
 
+# Workaround for issue when image is created with "docker commit".
+# Thanks to @SaadRana17
+# https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/131#issuecomment-2184156856
+
+if [ -e /tmp/.X1-lock ]; then
+    rm -f /tmp/.X1-lock
+fi
+if [ -e /tmp/.X11-unix/X1 ]; then
+    rm -f /tmp/.X11-unix/X1
+fi
+
 if [ $(uname -m) = "aarch64" ]; then
     LD_PRELOAD=/lib/aarch64-linux-gnu/libgcc_s.so.1 vncserver :1 -fg -geometry 1920x1080 -depth 24
 else
@@ -162,7 +173,7 @@ Comment[nb]=Surf på nettet
 Comment[nl]=Verken het internet
 Comment[nn]=Surf på nettet
 Comment[no]=Surf på nettet
-Comment[pl]=Przeglądanie stron WWW 
+Comment[pl]=Przeglądanie stron WWW
 Comment[pt]=Navegue na Internet
 Comment[pt_BR]=Navegue na Internet
 Comment[ro]=Navigați pe Internet
@@ -234,7 +245,7 @@ Keywords[it]=Internet;WWW;Browser;Web;Navigatore
 Keywords[is]=Internet;WWW;Vafri;Vefur;Netvafri;Flakk
 Keywords[ja]=Internet;WWW;Web;インターネット;ブラウザ;ウェブ;エクスプローラ
 Keywords[nb]=Internett;WWW;Nettleser;Explorer;Web;Browser;Nettside
-Keywords[nl]=Internet;WWW;Browser;Web;Explorer;Verkenner;Website;Surfen;Online 
+Keywords[nl]=Internet;WWW;Browser;Web;Explorer;Verkenner;Website;Surfen;Online
 Keywords[pt]=Internet;WWW;Browser;Web;Explorador;Navegador
 Keywords[pt_BR]=Internet;WWW;Browser;Web;Explorador;Navegador
 Keywords[ru]=Internet;WWW;Browser;Web;Explorer;интернет;браузер;веб;файрфокс;огнелис
@@ -286,7 +297,7 @@ Name[ru]=Новое окно
 Name[sk]=Otvoriť nové okno
 Name[sl]=Odpri novo okno
 Name[sv]=Öppna ett nytt fönster
-Name[tr]=Yeni pencere aç 
+Name[tr]=Yeni pencere aç
 Name[ug]=يېڭى كۆزنەك ئېچىش
 Name[uk]=Відкрити нове вікно
 Name[vi]=Mở cửa sổ mới

--- a/humble/entrypoint.sh
+++ b/humble/entrypoint.sh
@@ -42,6 +42,17 @@ VNCRUN_PATH=$HOME/.vnc/vnc_run.sh
 cat << EOF > $VNCRUN_PATH
 #!/bin/sh
 
+# Workaround for issue when image is created with "docker commit".
+# Thanks to @SaadRana17
+# https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/131#issuecomment-2184156856
+
+if [ -e /tmp/.X1-lock ]; then
+    rm -f /tmp/.X1-lock
+fi
+if [ -e /tmp/.X11-unix/X1 ]; then
+    rm -f /tmp/.X11-unix/X1
+fi
+
 if [ $(uname -m) = "aarch64" ]; then
     LD_PRELOAD=/lib/aarch64-linux-gnu/libgcc_s.so.1 vncserver :1 -fg -geometry 1920x1080 -depth 24
 else
@@ -345,8 +356,6 @@ VNC_PASSWORD=
 echo "============================================================================================"
 echo "NOTE 1: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
 echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
-echo "NOTE 2: Before stopping to commit docker container to new docker image, log out first."
-echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e]8;;\e\\'
 echo "============================================================================================"
 
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf

--- a/iron/entrypoint.sh
+++ b/iron/entrypoint.sh
@@ -42,6 +42,17 @@ VNCRUN_PATH=$HOME/.vnc/vnc_run.sh
 cat << EOF > $VNCRUN_PATH
 #!/bin/sh
 
+# Workaround for issue when image is created with "docker commit".
+# Thanks to @SaadRana17
+# https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/131#issuecomment-2184156856
+
+if [ -e /tmp/.X1-lock ]; then
+    rm -f /tmp/.X1-lock
+fi
+if [ -e /tmp/.X11-unix/X1 ]; then
+    rm -f /tmp/.X11-unix/X1
+fi
+
 if [ $(uname -m) = "aarch64" ]; then
     LD_PRELOAD=/lib/aarch64-linux-gnu/libgcc_s.so.1 vncserver :1 -fg -geometry 1920x1080 -depth 24
 else
@@ -345,8 +356,6 @@ VNC_PASSWORD=
 echo "============================================================================================"
 echo "NOTE 1: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
 echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
-echo "NOTE 2: Before stopping to commit docker container to new docker image, log out first."
-echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e]8;;\e\\'
 echo "============================================================================================"
 
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf

--- a/jazzy/entrypoint.sh
+++ b/jazzy/entrypoint.sh
@@ -42,6 +42,17 @@ VNCRUN_PATH="$HOME/.vnc/vnc_run.sh"
 cat << EOF > "$VNCRUN_PATH"
 #!/bin/sh
 
+# Workaround for issue when image is created with "docker commit".
+# Thanks to @SaadRana17
+# https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/131#issuecomment-2184156856
+
+if [ -e /tmp/.X1-lock ]; then
+    rm -f /tmp/.X1-lock
+fi
+if [ -e /tmp/.X11-unix/X1 ]; then
+    rm -f /tmp/.X11-unix/X1
+fi
+
 if [ $(uname -m) = "aarch64" ]; then
     LD_PRELOAD=/lib/aarch64-linux-gnu/libgcc_s.so.1 vncserver :1 -fg -geometry 1920x1080 -depth 24
 else
@@ -345,8 +356,6 @@ VNC_PASSWORD=
 echo "============================================================================================"
 echo "NOTE 1: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
 echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
-echo "NOTE 2: Before stopping to commit docker container to new docker image, log out first."
-echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e]8;;\e\\'
 echo "============================================================================================"
 
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Add workaround for issue when image is created with "docker commit"

Thanks @SaadRana17!

https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/131#issuecomment-2184156856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented workarounds for issues related to Docker image creation using "docker commit."
  - Removed lock files before starting VNC server to prevent related issues.

- **Improvements**
  - Removed outdated notes about logging out before stopping to commit a Docker container.
  - Added a note about the security-opt flag requirement for launching the Ubuntu Jammy-based image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->