### PR TITLE
feat(ci): Add ROS 2 Jazzy to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     directories:
       - "/humble"
       - "/iron"
+      - "/jazzy"
       - "/rolling"
     schedule:
       interval: "daily"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Included the "/jazzy" directory in Dependabot configuration to ensure dependencies in this directory are kept up-to-date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->