### PR TITLE
chore(ci): Use Trivy cache

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -81,6 +81,9 @@ runs:
         template: '@/contrib/sarif.tpl'
         output: 'trivy-results.sarif'
         timeout: '20m'
+      env:
+        TRIVY_SKIP_DB_UPDATE: true
+        TRIVY_SKIP_JAVA_DB_UPDATE: true
 
     - name: Cleanup docker image cache
       env:


### PR DESCRIPTION
- https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to enhance the Trivy vulnerability scanner by adding environment variables to skip database updates.
	- Minor formatting adjustments for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->