### PR TITLE
fix(ci): Fix oras command not found error

### DIFF
--- a/.github/workflows/update-trivy-cache.yaml
+++ b/.github/workflows/update-trivy-cache.yaml
@@ -11,6 +11,9 @@ jobs:
   update-trivy-db:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup oras
+        uses: oras-project/setup-oras@v1
+
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
the latest ubuntu image has been updated and "oras" command not found in the new image

![image](https://github.com/user-attachments/assets/8cecd2b1-d4c5-4016-8a84-77f0b343b609)


![Screenshot from 2024-10-15 10-45-27](https://github.com/user-attachments/assets/c69944ea-2968-42b9-9596-541336d0e208)
![Screenshot from 2024-10-15 10-45-30](https://github.com/user-attachments/assets/e5e94a25-dd0c-4264-a240-bfb60eb171e4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to include a new setup step for the ORAS tool, enhancing the environment for vulnerability database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->