### PR TITLE
feat: Enable Gazebo on arm64 Jazzy/Rolling

### DIFF
--- a/jazzy/Dockerfile
+++ b/jazzy/Dockerfile
@@ -114,16 +114,11 @@ RUN apt-get update -q && \
 
 RUN rosdep update
 
-# Install simulation packages are
-# not ready for amd64/arm64 for now (May 27th, 2024)
-# https://repo.ros2.org/status_page/jazzy_default.html?q=RED
-# RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-#     apt-get update -q && \
-#     apt-get install -y \
-#     ros-${ROS_DISTRO}-gazebo-ros-pkgs \
-#     ros-${ROS_DISTRO}-ros-gz && \
-#     rm -rf /var/lib/apt/lists/*; \
-#     fi
+# Install simulation packages
+RUN apt-get update -q && \
+    apt-get install -y \
+    ros-${ROS_DISTRO}-ros-gz && \
+    rm -rf /var/lib/apt/lists/*
 
 # Enable apt-get completion after running `apt-get update` in the container
 RUN rm /etc/apt/apt.conf.d/docker-clean

--- a/jazzy/entrypoint.sh
+++ b/jazzy/entrypoint.sh
@@ -349,13 +349,17 @@ Icon=vscodium
 EOF
 chown -R "$USER:$USER" "$HOME/Desktop"
 
+echo "============================================================================================"
+echo "Launched docker container."
+echo -e 'Open \e]8;;http://127.0.0.1:6080\e\\http://127.0.0.1:6080\e]8;;\e\\ via web browser.'
+echo ""
+echo "NOTE 1: Default user is \"$USER\", password is \"$PASSWORD\"."
+echo "NOTE 2: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy/Noble based image on some environment."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "============================================================================================"
+
 # clearup
 PASSWORD=
 VNC_PASSWORD=
-
-echo "============================================================================================"
-echo "NOTE 1: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
-echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
-echo "============================================================================================"
 
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf

--- a/rolling/Dockerfile
+++ b/rolling/Dockerfile
@@ -114,16 +114,11 @@ RUN apt-get update -q && \
 
 RUN rosdep update
 
-# Install simulation packages are
-# not ready for amd64/arm64 for now (May 24th, 2023)
-# https://repo.ros2.org/status_page/rolling_default.html?q=RED
-# RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-#     apt-get update -q && \
-#     apt-get install -y \
-#     ros-${ROS_DISTRO}-gazebo-ros-pkgs \
-#     ros-${ROS_DISTRO}-ros-gz && \
-#     rm -rf /var/lib/apt/lists/*; \
-#     fi
+# Install simulation packages
+RUN apt-get update -q && \
+    apt-get install -y \
+    ros-${ROS_DISTRO}-ros-gz && \
+    rm -rf /var/lib/apt/lists/*
 
 # Enable apt-get completion after running `apt-get update` in the container
 RUN rm /etc/apt/apt.conf.d/docker-clean

--- a/rolling/entrypoint.sh
+++ b/rolling/entrypoint.sh
@@ -338,15 +338,17 @@ Icon=vscodium
 EOF
 chown -R "$USER:$USER" "$HOME/Desktop"
 
+echo "============================================================================================"
+echo "Launched docker container."
+echo -e 'Open \e]8;;http://127.0.0.1:6080\e\\http://127.0.0.1:6080\e]8;;\e\\ via web browser.'
+echo ""
+echo "NOTE 1: Default user is \"$USER\", password is \"$PASSWORD\"."
+echo "NOTE 2: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy/Noble based image on some environment."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "============================================================================================"
+
 # clearup
 PASSWORD=
 VNC_PASSWORD=
-
-echo "============================================================================================"
-echo "NOTE 1: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy based image."
-echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
-echo "NOTE 2: Before stopping to commit docker container to new docker image, log out first."
-echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/issue/131\e]8;;\e\\'
-echo "============================================================================================"
 
 exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Thanks to @takasehideki, new Gazebo was able to use on arm64 image

<img width="1683" alt="スクリーンショット 2024-12-28 18 59 11" src="https://github.com/user-attachments/assets/d19294db-956a-4cdb-ba2e-3a87f0f592b2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Dockerfiles for Jazzy and Rolling ROS distributions
	- Enhanced entrypoint scripts with clearer user instructions
	- Added more informative launch messages and access URLs

- **Chores**
	- Simplified ROS simulation package installation process
	- Improved security practices in container startup scripts
	- Cleaned up commented code and installation conditionals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->