### PR TITLE
fix: Fix firefox launch error

### DIFF
--- a/jazzy/Dockerfile
+++ b/jazzy/Dockerfile
@@ -75,9 +75,11 @@ RUN wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg \
     -O /etc/apt/keyrings/packages.mozilla.org.asc && \
     echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" \
     | tee -a /etc/apt/sources.list.d/mozilla-apt.list && \
-    echo 'Package: *Pin: origin packages.mozilla.orgPin-Priority: 900' \
-    | tee /etc/apt/preferences.d/mozilla-apt && \
+    echo "Package: *" | tee /etc/apt/preferences.d/mozilla > /dev/null && \
+    echo "Pin: origin packages.mozilla.org" | tee -a /etc/apt/preferences.d/mozilla > /dev/null && \
+    echo "Pin-Priority: 1000" | tee -a /etc/apt/preferences.d/mozilla > /dev/null && \
     apt-get update -q && \
+    apt-get remove -y firefox && \
     apt-get install -y \
     firefox && \
     apt-get autoclean && \

--- a/rolling/Dockerfile
+++ b/rolling/Dockerfile
@@ -75,9 +75,11 @@ RUN wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg \
     -O /etc/apt/keyrings/packages.mozilla.org.asc && \
     echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" \
     | tee -a /etc/apt/sources.list.d/mozilla-apt.list && \
-    echo 'Package: *Pin: origin packages.mozilla.orgPin-Priority: 900' \
-    | tee /etc/apt/preferences.d/mozilla-apt && \
+    echo "Package: *" | tee /etc/apt/preferences.d/mozilla > /dev/null && \
+    echo "Pin: origin packages.mozilla.org" | tee -a /etc/apt/preferences.d/mozilla > /dev/null && \
+    echo "Pin-Priority: 1000" | tee -a /etc/apt/preferences.d/mozilla > /dev/null && \
     apt-get update -q && \
+    apt-get remove -y firefox && \
     apt-get install -y \
     firefox && \
     apt-get autoclean && \


### PR DESCRIPTION
https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfiles for `jazzy` and `rolling` distributions
  - Refined package management process for Mozilla repository
  - Added explicit Firefox removal before reinstallation
  - Updated APT repository preference settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->