### PR TITLE
Add ROS 2 Lyrical support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       - "/humble"
       - "/iron"
       - "/jazzy"
+      - "/lyrical"
       - "/rolling"
     schedule:
       interval: "daily"

--- a/.github/workflows/deploy-lyrical.yml
+++ b/.github/workflows/deploy-lyrical.yml
@@ -1,0 +1,35 @@
+name: Publish to Registry (Lyrical)
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "lyrical/**"
+      - ".github/workflows/deploy-lyrical.yml"
+      - ".github/actions/deploy/action.yml"
+  schedule:
+    - cron: "7 4 * * 0" # Weekly on Sundays at 13:07 (JST)
+  workflow_dispatch:
+
+env:
+  DOCKER_USERNAME: tiryoh
+  DOCKER_IMAGENAME: ros2-desktop-vnc
+  GIT_CONFIG_USER: Tiryoh@GitHubActions
+  GIT_CONFIG_EMAIL: tiryoh@gmail.com
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+      - uses: ./.github/actions/deploy
+        with:
+          ros-distro: lyrical
+          latest: false
+          gha-job-name: build-and-deploy
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-lyrical.yml
+++ b/.github/workflows/test-lyrical.yml
@@ -1,0 +1,38 @@
+name: Build and Test (Lyrical)
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "lyrical/**"
+      - ".github/workflows/test-lyrical.yml"
+      - ".github/actions/test/action.yml"
+  schedule:
+    - cron: "0 2 * * 0" # Weekly on Sundays at 02:00
+  workflow_dispatch:
+
+env:
+  DOCKER_USERNAME: tiryoh
+  DOCKER_IMAGENAME: ros2-desktop-vnc
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+      - uses: ./.github/actions/test
+        with:
+          ros-distro: lyrical
+          arch: ${{ matrix.arch }}

--- a/.github/workflows/update-ros-apt-source.yml
+++ b/.github/workflows/update-ros-apt-source.yml
@@ -1,0 +1,71 @@
+name: Update ros-apt-source
+
+on:
+  schedule:
+    - cron: "23 2 1 * *" # Monthly on the 1st at 02:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check latest ros-apt-source version
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest=$(gh api repos/ros-infrastructure/ros-apt-source/releases/latest --jq .tag_name)
+          echo "latest=${latest}" >> "$GITHUB_OUTPUT"
+
+          current=$(grep -Rho '^ARG ROS_APT_SOURCE_VERSION=.*' */Dockerfile | head -n1 | cut -d= -f2)
+          echo "current=${current}" >> "$GITHUB_OUTPUT"
+
+          if [ -z "$current" ]; then
+            echo "No ROS_APT_SOURCE_VERSION pins found."
+            exit 0
+          fi
+
+          if [ "$latest" = "$current" ]; then
+            echo "No update needed."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Update Dockerfiles
+        if: steps.version.outputs.changed == 'true'
+        env:
+          LATEST_VERSION: ${{ steps.version.outputs.latest }}
+        run: |
+          grep -Rl '^ARG ROS_APT_SOURCE_VERSION=' */Dockerfile | while read -r dockerfile; do
+            sed -i -E "s/^ARG ROS_APT_SOURCE_VERSION=.*/ARG ROS_APT_SOURCE_VERSION=${LATEST_VERSION}/" "$dockerfile"
+          done
+
+      - name: Create pull request
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_VERSION: ${{ steps.version.outputs.latest }}
+        run: |
+          branch="github-actions/update-ros-apt-source-${LATEST_VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add '*/Dockerfile'
+          git commit -m "Update ros-apt-source to ${LATEST_VERSION}"
+          git push --force-with-lease origin "$branch"
+
+          gh pr view "$branch" --json url >/dev/null 2>&1 || \
+            gh pr create \
+              --base master \
+              --head "$branch" \
+              --title "Update ros-apt-source to ${LATEST_VERSION}" \
+              --body "Update pinned ros-apt-source version from ${{ steps.version.outputs.current }} to ${LATEST_VERSION}."

--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ https://memoteki.net/archives/2955
 Run the docker container and access with port `6080`.  
 Change the `shm-size` value depending on the situation.
 
-__NOTE__: `--security-opt seccomp=unconfined` flag is required to launch humble image. See https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56.
-
 ```
-docker run -p 6080:80 --security-opt seccomp=unconfined --shm-size=512m ghcr.io/tiryoh/ros2-desktop-vnc:humble
+docker run -p 6080:80 --shm-size=512m ghcr.io/tiryoh/ros2-desktop-vnc:lyrical
 ```
 
 Browse http://127.0.0.1:6080/.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Publish to Registry (Humble)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-humble.yml/badge.svg)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-humble.yml)
 [![Publish to Registry (Iron)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-iron.yml/badge.svg)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-iron.yml)
 [![Publish to Registry (Jazzy)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-jazzy.yml/badge.svg)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-jazzy.yml)
+[![Publish to Registry (Lyrical)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-lyrical.yml/badge.svg)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-lyrical.yml)
 [![Publish to Registry (Rolling)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-rolling.yml/badge.svg)](https://github.com/Tiryoh/docker-ros2-desktop-vnc/actions/workflows/deploy-rolling.yml)
 
 [![Docker Automated build](https://img.shields.io/docker/automated/tiryoh/ros2-desktop-vnc)](https://hub.docker.com/r/tiryoh/ros2-desktop-vnc)
@@ -91,6 +92,16 @@ cd jazzy && docker buildx build --platform=linux/amd64 --progress=plain -t tiryo
 cd jazzy && docker buildx build --platform=linux/arm64 --progress=plain -t tiryoh/ros2-desktop-vnc:jazzy-arm64 .
 ```
 
+* lyrical
+```sh
+# using "docker build"
+cd lyrical && docker build -t tiryoh/ros2-desktop-vnc:lyrical .
+# using "docker buildx" (amd64)
+cd lyrical && docker buildx build --platform=linux/amd64 --progress=plain -t tiryoh/ros2-desktop-vnc:lyrical-amd64 .
+# using "docker buildx" (arm64)
+cd lyrical && docker buildx build --platform=linux/arm64 --progress=plain -t tiryoh/ros2-desktop-vnc:lyrical-arm64 .
+```
+
 * rolling
 ```sh
 # using "docker build"
@@ -110,6 +121,7 @@ cd rolling && docker buildx build --platform=linux/arm64 --progress=plain -t tir
 * [`humble`](https://hub.docker.com/r/tiryoh/ros2-desktop-vnc/tags?page=1&name=humble), [`latest`](https://hub.docker.com/r/tiryoh/ros2-desktop-vnc/tags?page=1&name=latest) which is based on [`humble/Dockerfile`](./humble/Dockerfile)
 * [`iron`](https://hub.docker.com/r/tiryoh/ros2-desktop-vnc/tags?page=1&name=iron) which is based on [`iron/Dockerfile`](./iron/Dockerfile)
 * [`jazzy`](https://hub.docker.com/r/tiryoh/ros2-desktop-vnc/tags?page=1&name=jazzy) which is based on [`jazzy/Dockerfile`](./jazzy/Dockerfile)
+* [`lyrical`](https://hub.docker.com/r/tiryoh/ros2-desktop-vnc/tags?page=1&name=lyrical) which is based on [`lyrical/Dockerfile`](./lyrical/Dockerfile)
 * [`rolling`](https://hub.docker.com/r/tiryoh/ros2-desktop-vnc/tags?page=1&name=rolling) which is based on [`rolling/Dockerfile`](./rolling/Dockerfile)
 
 Docker tags and build logs are listed on this page.  
@@ -130,7 +142,7 @@ This repository is released under the Apache License 2.0, see [LICENSE](./LICENS
 Unless attributed otherwise, everything in this repository is under the Apache License 2.0.
 
 ```
-Copyright 2020-2025 Tiryoh <tiryoh@gmail.com>
+Copyright 2020-2026 Tiryoh <tiryoh@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,6 +6,7 @@ group "default" {
     "iron",
     "jazzy",
     "kilted",
+    "lyrical",
     "rolling"
     ]
 }
@@ -42,7 +43,7 @@ target "jazzy" {
   inherits = ["common"]
   context = "jazzy"
   tags = [
-    "${REGISTRY_PREFIX}:jazzy"
+    "${REGISTRY_PREFIX}:jazzy",
     "${REGISTRY_PREFIX}:latest"
   ]
   platforms = ["linux/amd64", "linux/arm64"]
@@ -53,6 +54,15 @@ target "kilted" {
   context = "kilted"
   tags = [
     "${REGISTRY_PREFIX}:kilted"
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "lyrical" {
+  inherits = ["common"]
+  context = "lyrical"
+  tags = [
+    "${REGISTRY_PREFIX}:lyrical"
   ]
   platforms = ["linux/amd64", "linux/arm64"]
 }

--- a/lyrical/Dockerfile
+++ b/lyrical/Dockerfile
@@ -1,0 +1,138 @@
+# https://github.com/Tiryoh/docker-ros2-desktop-vnc
+# Copyright 2020-2026 Tiryoh<tiryoh@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This Dockerfile is based on https://github.com/AtsushiSaito/docker-ubuntu-sweb
+# which is released under the Apache-2.0 license.
+#
+# The TigerVNC startup workaround for Ubuntu 26.04 is based on
+# https://github.com/atinfinity/docker-ubuntu-sweb by atinfinity.
+
+FROM ubuntu:resolute-20260404
+
+# Automatic platform ARGs in the global scope
+# https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
+# The QEMU_CPU option is used to speed up arm64 image builds,
+# amd64 is unaffected as it does not use QEMU.
+# This environment variable is only declared at build time.
+ARG QEMU_CPU
+
+LABEL maintainer="Tiryoh<tiryoh@gmail.com>"
+
+SHELL ["/bin/bash", "-c"]
+
+# Upgrade OS
+RUN apt-get update -q && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    apt-get autoclean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Ubuntu Mate desktop
+RUN apt-get update -q && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        ubuntu-mate-desktop && \
+    apt-get autoclean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add Package
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        tigervnc-standalone-server tigervnc-common \
+        supervisor wget curl gosu git sudo python3-full python3-pip tini \
+        build-essential vim sudo lsb-release locales \
+        bash-completion tzdata terminator dbus-x11 && \
+    apt-get autoclean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+# noVNC and Websockify
+RUN git clone https://github.com/AtsushiSaito/noVNC.git -b add_clipboard_support /usr/lib/novnc
+RUN pip install --no-cache-dir --break-system-packages git+https://github.com/novnc/websockify.git@v0.10.0
+RUN ln -s /usr/lib/novnc/vnc.html /usr/lib/novnc/index.html
+
+# Set remote resize function enabled by default
+RUN sed -i "s/UI.initSetting('resize', 'off');/UI.initSetting('resize', 'remote');/g" /usr/lib/novnc/app/ui.js
+
+# Disable auto update and crash report
+RUN sed -i 's/Prompt=.*/Prompt=never/' /etc/update-manager/release-upgrades
+RUN sed -i 's/enabled=1/enabled=0/g' /etc/default/apport
+
+# Install Firefox
+RUN wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg \
+    -O /etc/apt/keyrings/packages.mozilla.org.asc && \
+    echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" \
+    | tee -a /etc/apt/sources.list.d/mozilla-apt.list && \
+    echo "Package: *" | tee /etc/apt/preferences.d/mozilla > /dev/null && \
+    echo "Pin: origin packages.mozilla.org" | tee -a /etc/apt/preferences.d/mozilla > /dev/null && \
+    echo "Pin-Priority: 1000" | tee -a /etc/apt/preferences.d/mozilla > /dev/null && \
+    apt-get update -q && \
+    apt-get remove -y firefox && \
+    apt-get install -y \
+    firefox && \
+    apt-get autoclean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install VSCodium
+RUN wget https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg \
+    -O /usr/share/keyrings/vscodium-archive-keyring.asc && \
+    echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.asc ] https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs vscodium main' \
+    | tee /etc/apt/sources.list.d/vscodium.list && \
+    apt-get update -q && \
+    apt-get install -y codium && \
+    apt-get autoclean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install ROS
+ENV ROS_DISTRO=lyrical
+# desktop or ros-base
+ARG INSTALL_PACKAGE=desktop
+
+RUN apt-get update -q && \
+    apt-get install -y curl gnupg2 lsb-release && \
+    export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}') && \
+    curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb" && \
+    dpkg -i /tmp/ros2-apt-source.deb && \
+    apt-get update -q && \
+    apt-get install -y ros-${ROS_DISTRO}-${INSTALL_PACKAGE} \
+    python3-argcomplete \
+    python3-colcon-common-extensions \
+    python3-rosdep python3-vcstool && \
+    rosdep init && \
+    rm -f /tmp/ros2-apt-source.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rosdep update
+
+# Install simulation packages
+RUN apt-get update -q && \
+    apt-get install -y \
+    ros-${ROS_DISTRO}-ros-gz && \
+    rm -rf /var/lib/apt/lists/*
+
+# Enable apt-get completion after running `apt-get update` in the container
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
+COPY ./entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/bin/bash", "-c", "/entrypoint.sh" ]
+
+ENV USER=ubuntu
+ENV PASSWD=ubuntu

--- a/lyrical/Dockerfile
+++ b/lyrical/Dockerfile
@@ -104,10 +104,14 @@ RUN wget https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
 ENV ROS_DISTRO=lyrical
 # desktop or ros-base
 ARG INSTALL_PACKAGE=desktop
+# The official ROS 2 install docs resolve ros-apt-source from the latest GitHub
+# release with this command:
+# ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
+# Pin it here for reproducible Docker builds; update it via GitHub Actions.
+ARG ROS_APT_SOURCE_VERSION=1.2.0
 
 RUN apt-get update -q && \
     apt-get install -y curl gnupg2 lsb-release && \
-    export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}') && \
     curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb" && \
     dpkg -i /tmp/ros2-apt-source.deb && \
     apt-get update -q && \

--- a/lyrical/entrypoint.sh
+++ b/lyrical/entrypoint.sh
@@ -363,7 +363,8 @@ echo "Launched docker container."
 echo -e 'Open \e]8;;http://127.0.0.1:6080\e\\http://127.0.0.1:6080\e]8;;\e\\ via web browser.'
 echo ""
 echo "NOTE 1: Default user is \"$USER\", password is \"$PASSWORD\"."
-echo "NOTE 2: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy/Noble based image on some environment."
+echo "NOTE 2: --security-opt seccomp=unconfined may be required on older host environments."
+echo "        Add it only if the container fails to start because of the host seccomp profile."
 echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
 echo "============================================================================================"
 

--- a/lyrical/entrypoint.sh
+++ b/lyrical/entrypoint.sh
@@ -1,0 +1,374 @@
+#!/bin/bash
+
+# Create User
+USER=${USER:-root}
+HOME=/root
+if [ "$USER" != "root" ]; then
+    echo "* enable custom user: $USER"
+    useradd --create-home --shell /bin/bash --user-group --groups adm,sudo "$USER"
+    echo "$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    if [ -z "$PASSWORD" ]; then
+        echo "  set default password to \"ubuntu\""
+        PASSWORD=ubuntu
+    fi
+    HOME="/home/$USER"
+    echo "$USER:$PASSWORD" | /usr/sbin/chpasswd 2> /dev/null || echo ""
+    cp -r /root/{.config,.gtkrc-2.0,.asoundrc} "$HOME" 2>/dev/null
+    chown -R "$USER:$USER" "$HOME"
+    [ -d "/dev/snd" ] && chgrp -R adm /dev/snd
+fi
+
+# VNC password
+VNC_PASSWORD=${PASSWORD:-ubuntu}
+
+# TigerVNC on Ubuntu 26.04 uses ~/.config/tigervnc.
+# Thanks to atinfinity: https://github.com/atinfinity/docker-ubuntu-sweb
+mkdir -p "$HOME/.vnc" "$HOME/.config/tigervnc"
+echo "$VNC_PASSWORD" | vncpasswd -f > "$HOME/.vnc/passwd"
+echo "$VNC_PASSWORD" | vncpasswd -f > "$HOME/.config/tigervnc/passwd"
+chmod 600 "$HOME/.vnc/passwd" "$HOME/.config/tigervnc/passwd"
+chown -R "$USER:$USER" "$HOME"
+sed -i "s/password = WebUtil.getConfigVar('password');/password = '$VNC_PASSWORD'/" /usr/lib/novnc/app/ui.js
+
+# xstartup
+# Keep xstartup in both TigerVNC config locations for compatibility.
+XSTARTUP_PATH="$HOME/.vnc/xstartup"
+cat << EOF > "$XSTARTUP_PATH"
+#!/bin/sh
+unset SESSION_MANAGER
+unset DBUS_SESSION_BUS_ADDRESS
+export XDG_SESSION_TYPE=x11
+exec dbus-launch --exit-with-session mate-session
+EOF
+chown "$USER:$USER" "$XSTARTUP_PATH"
+chmod 755 "$XSTARTUP_PATH"
+cp "$XSTARTUP_PATH" "$HOME/.config/tigervnc/xstartup"
+chown "$USER:$USER" "$HOME/.config/tigervnc/xstartup"
+chmod 755 "$HOME/.config/tigervnc/xstartup"
+
+# vncserver launch
+VNCRUN_PATH="$HOME/.vnc/vnc_run.sh"
+cat << EOF > "$VNCRUN_PATH"
+#!/bin/sh
+
+# Workaround for issue when image is created with "docker commit".
+# Thanks to @SaadRana17
+# https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/131#issuecomment-2184156856
+
+if [ -e /tmp/.X1-lock ]; then
+    rm -f /tmp/.X1-lock
+fi
+if [ -e /tmp/.X11-unix/X1 ]; then
+    rm -f /tmp/.X11-unix/X1
+fi
+
+if [ $(uname -m) = "aarch64" ]; then
+    LD_PRELOAD=/lib/aarch64-linux-gnu/libgcc_s.so.1 vncserver :1 -fg -geometry 1920x1080 -depth 24
+else
+    vncserver :1 -fg -geometry 1920x1080 -depth 24
+fi
+EOF
+
+# Supervisor
+CONF_PATH=/etc/supervisor/conf.d/supervisord.conf
+cat << EOF > $CONF_PATH
+[supervisord]
+nodaemon=true
+user=root
+[program:vnc]
+command=gosu '$USER' bash '$VNCRUN_PATH'
+[program:novnc]
+command=gosu '$USER' bash -c "websockify --web=/usr/lib/novnc 80 localhost:5901"
+EOF
+
+# colcon
+BASHRC_PATH="$HOME/.bashrc"
+grep -F "source /opt/ros/$ROS_DISTRO/setup.bash" "$BASHRC_PATH" || echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> "$BASHRC_PATH"
+grep -F "export ROS_AUTOMATIC_DISCOVERY_RANGE=" "$BASHRC_PATH" || echo "# export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST" >> "$BASHRC_PATH"
+chown "$USER:$USER" "$BASHRC_PATH"
+
+# Fix rosdep permission
+mkdir -p "$HOME/.ros"
+cp -r /root/.ros/rosdep "$HOME/.ros/rosdep"
+chown -R "$USER:$USER" "$HOME/.ros"
+
+# Add terminator shortcut
+mkdir -p "$HOME/Desktop"
+cat << EOF > "$HOME/Desktop/terminator.desktop"
+[Desktop Entry]
+Name=Terminator
+Comment=Multiple terminals in one window
+TryExec=terminator
+Exec=terminator
+Icon=terminator
+Type=Application
+Categories=GNOME;GTK;Utility;TerminalEmulator;System;
+StartupNotify=true
+X-Ubuntu-Gettext-Domain=terminator
+X-Ayatana-Desktop-Shortcuts=NewWindow;
+Keywords=terminal;shell;prompt;command;commandline;
+[NewWindow Shortcut Group]
+Name=Open a New Window
+Exec=terminator
+TargetEnvironment=Unity
+EOF
+cat << EOF > "$HOME/Desktop/firefox.desktop"
+[Desktop Entry]
+Version=1.0
+Name=Firefox Web Browser
+Name[ar]=متصفح الويب فَيَرفُكْس
+Name[ast]=Restolador web Firefox
+Name[bn]=ফায়ারফক্স ওয়েব ব্রাউজার
+Name[ca]=Navegador web Firefox
+Name[cs]=Firefox Webový prohlížeč
+Name[da]=Firefox - internetbrowser
+Name[el]=Περιηγητής Firefox
+Name[es]=Navegador web Firefox
+Name[et]=Firefoxi veebibrauser
+Name[fa]=مرورگر اینترنتی Firefox
+Name[fi]=Firefox-selain
+Name[fr]=Navigateur Web Firefox
+Name[gl]=Navegador web Firefox
+Name[he]=דפדפן האינטרנט Firefox
+Name[hr]=Firefox web preglednik
+Name[hu]=Firefox webböngésző
+Name[it]=Firefox Browser Web
+Name[ja]=Firefox ウェブ・ブラウザ
+Name[ko]=Firefox 웹 브라우저
+Name[ku]=Geroka torê Firefox
+Name[lt]=Firefox interneto naršyklė
+Name[nb]=Firefox Nettleser
+Name[nl]=Firefox webbrowser
+Name[nn]=Firefox Nettlesar
+Name[no]=Firefox Nettleser
+Name[pl]=Przeglądarka WWW Firefox
+Name[pt]=Firefox Navegador Web
+Name[pt_BR]=Navegador Web Firefox
+Name[ro]=Firefox – Navigator Internet
+Name[ru]=Веб-браузер Firefox
+Name[sk]=Firefox - internetový prehliadač
+Name[sl]=Firefox spletni brskalnik
+Name[sv]=Firefox webbläsare
+Name[tr]=Firefox Web Tarayıcısı
+Name[ug]=Firefox توركۆرگۈ
+Name[uk]=Веб-браузер Firefox
+Name[vi]=Trình duyệt web Firefox
+Name[zh_CN]=Firefox 网络浏览器
+Name[zh_TW]=Firefox 網路瀏覽器
+Comment=Browse the World Wide Web
+Comment[ar]=تصفح الشبكة العنكبوتية العالمية
+Comment[ast]=Restola pela Rede
+Comment[bn]=ইন্টারনেট ব্রাউজ করুন
+Comment[ca]=Navegueu per la web
+Comment[cs]=Prohlížení stránek World Wide Webu
+Comment[da]=Surf på internettet
+Comment[de]=Im Internet surfen
+Comment[el]=Μπορείτε να περιηγηθείτε στο διαδίκτυο (Web)
+Comment[es]=Navegue por la web
+Comment[et]=Lehitse veebi
+Comment[fa]=صفحات شبکه جهانی اینترنت را مرور نمایید
+Comment[fi]=Selaa Internetin WWW-sivuja
+Comment[fr]=Naviguer sur le Web
+Comment[gl]=Navegar pola rede
+Comment[he]=גלישה ברחבי האינטרנט
+Comment[hr]=Pretražite web
+Comment[hu]=A világháló böngészése
+Comment[it]=Esplora il web
+Comment[ja]=ウェブを閲覧します
+Comment[ko]=웹을 돌아 다닙니다
+Comment[ku]=Li torê bigere
+Comment[lt]=Naršykite internete
+Comment[nb]=Surf på nettet
+Comment[nl]=Verken het internet
+Comment[nn]=Surf på nettet
+Comment[no]=Surf på nettet
+Comment[pl]=Przeglądanie stron WWW
+Comment[pt]=Navegue na Internet
+Comment[pt_BR]=Navegue na Internet
+Comment[ro]=Navigați pe Internet
+Comment[ru]=Доступ в Интернет
+Comment[sk]=Prehliadanie internetu
+Comment[sl]=Brskajte po spletu
+Comment[sv]=Surfa på webben
+Comment[tr]=İnternet'te Gezinin
+Comment[ug]=دۇنيادىكى توربەتلەرنى كۆرگىلى بولىدۇ
+Comment[uk]=Перегляд сторінок Інтернету
+Comment[vi]=Để duyệt các trang web
+Comment[zh_CN]=浏览互联网
+Comment[zh_TW]=瀏覽網際網路
+GenericName=Web Browser
+GenericName[ar]=متصفح ويب
+GenericName[ast]=Restolador Web
+GenericName[bn]=ওয়েব ব্রাউজার
+GenericName[ca]=Navegador web
+GenericName[cs]=Webový prohlížeč
+GenericName[da]=Webbrowser
+GenericName[el]=Περιηγητής διαδικτύου
+GenericName[es]=Navegador web
+GenericName[et]=Veebibrauser
+GenericName[fa]=مرورگر اینترنتی
+GenericName[fi]=WWW-selain
+GenericName[fr]=Navigateur Web
+GenericName[gl]=Navegador Web
+GenericName[he]=דפדפן אינטרנט
+GenericName[hr]=Web preglednik
+GenericName[hu]=Webböngésző
+GenericName[it]=Browser web
+GenericName[ja]=ウェブ・ブラウザ
+GenericName[ko]=웹 브라우저
+GenericName[ku]=Geroka torê
+GenericName[lt]=Interneto naršyklė
+GenericName[nb]=Nettleser
+GenericName[nl]=Webbrowser
+GenericName[nn]=Nettlesar
+GenericName[no]=Nettleser
+GenericName[pl]=Przeglądarka WWW
+GenericName[pt]=Navegador Web
+GenericName[pt_BR]=Navegador Web
+GenericName[ro]=Navigator Internet
+GenericName[ru]=Веб-браузер
+GenericName[sk]=Internetový prehliadač
+GenericName[sl]=Spletni brskalnik
+GenericName[sv]=Webbläsare
+GenericName[tr]=Web Tarayıcı
+GenericName[ug]=توركۆرگۈ
+GenericName[uk]=Веб-браузер
+GenericName[vi]=Trình duyệt Web
+GenericName[zh_CN]=网络浏览器
+GenericName[zh_TW]=網路瀏覽器
+Keywords=Internet;WWW;Browser;Web;Explorer
+Keywords[ar]=انترنت;إنترنت;متصفح;ويب;وب
+Keywords[ast]=Internet;WWW;Restolador;Web;Esplorador
+Keywords[ca]=Internet;WWW;Navegador;Web;Explorador;Explorer
+Keywords[cs]=Internet;WWW;Prohlížeč;Web;Explorer
+Keywords[da]=Internet;Internettet;WWW;Browser;Browse;Web;Surf;Nettet
+Keywords[de]=Internet;WWW;Browser;Web;Explorer;Webseite;Site;surfen;online;browsen
+Keywords[el]=Internet;WWW;Browser;Web;Explorer;Διαδίκτυο;Περιηγητής;Firefox;Φιρεφοχ;Ιντερνετ
+Keywords[es]=Explorador;Internet;WWW
+Keywords[fi]=Internet;WWW;Browser;Web;Explorer;selain;Internet-selain;internetselain;verkkoselain;netti;surffaa
+Keywords[fr]=Internet;WWW;Browser;Web;Explorer;Fureteur;Surfer;Navigateur
+Keywords[he]=דפדפן;אינטרנט;רשת;אתרים;אתר;פיירפוקס;מוזילה;
+Keywords[hr]=Internet;WWW;preglednik;Web
+Keywords[hu]=Internet;WWW;Böngésző;Web;Háló;Net;Explorer
+Keywords[it]=Internet;WWW;Browser;Web;Navigatore
+Keywords[is]=Internet;WWW;Vafri;Vefur;Netvafri;Flakk
+Keywords[ja]=Internet;WWW;Web;インターネット;ブラウザ;ウェブ;エクスプローラ
+Keywords[nb]=Internett;WWW;Nettleser;Explorer;Web;Browser;Nettside
+Keywords[nl]=Internet;WWW;Browser;Web;Explorer;Verkenner;Website;Surfen;Online
+Keywords[pt]=Internet;WWW;Browser;Web;Explorador;Navegador
+Keywords[pt_BR]=Internet;WWW;Browser;Web;Explorador;Navegador
+Keywords[ru]=Internet;WWW;Browser;Web;Explorer;интернет;браузер;веб;файрфокс;огнелис
+Keywords[sk]=Internet;WWW;Prehliadač;Web;Explorer
+Keywords[sl]=Internet;WWW;Browser;Web;Explorer;Brskalnik;Splet
+Keywords[tr]=İnternet;WWW;Tarayıcı;Web;Gezgin;Web sitesi;Site;sörf;çevrimiçi;tara
+Keywords[uk]=Internet;WWW;Browser;Web;Explorer;Інтернет;мережа;переглядач;оглядач;браузер;веб;файрфокс;вогнелис;перегляд
+Keywords[vi]=Internet;WWW;Browser;Web;Explorer;Trình duyệt;Trang web
+Keywords[zh_CN]=Internet;WWW;Browser;Web;Explorer;网页;浏览;上网;火狐;Firefox;ff;互联网;网站;
+Keywords[zh_TW]=Internet;WWW;Browser;Web;Explorer;網際網路;網路;瀏覽器;上網;網頁;火狐
+Exec=firefox %u
+Terminal=false
+X-MultipleArgs=false
+Type=Application
+Icon=firefox
+Categories=GNOME;GTK;Network;WebBrowser;
+MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
+StartupNotify=true
+Actions=new-window;new-private-window;
+
+[Desktop Action new-window]
+Name=Open a New Window
+Name[ar]=افتح نافذة جديدة
+Name[ast]=Abrir una ventana nueva
+Name[bn]=Abrir una ventana nueva
+Name[ca]=Obre una finestra nova
+Name[cs]=Otevřít nové okno
+Name[da]=Åbn et nyt vindue
+Name[de]=Ein neues Fenster öffnen
+Name[el]=Νέο παράθυρο
+Name[es]=Abrir una ventana nueva
+Name[fi]=Avaa uusi ikkuna
+Name[fr]=Ouvrir une nouvelle fenêtre
+Name[gl]=Abrir unha nova xanela
+Name[he]=פתיחת חלון חדש
+Name[hr]=Otvori novi prozor
+Name[hu]=Új ablak nyitása
+Name[it]=Apri una nuova finestra
+Name[ja]=新しいウィンドウを開く
+Name[ko]=새 창 열기
+Name[ku]=Paceyeke nû veke
+Name[lt]=Atverti naują langą
+Name[nb]=Åpne et nytt vindu
+Name[nl]=Nieuw venster openen
+Name[pt]=Abrir nova janela
+Name[pt_BR]=Abrir nova janela
+Name[ro]=Deschide o fereastră nouă
+Name[ru]=Новое окно
+Name[sk]=Otvoriť nové okno
+Name[sl]=Odpri novo okno
+Name[sv]=Öppna ett nytt fönster
+Name[tr]=Yeni pencere aç
+Name[ug]=يېڭى كۆزنەك ئېچىش
+Name[uk]=Відкрити нове вікно
+Name[vi]=Mở cửa sổ mới
+Name[zh_CN]=新建窗口
+Name[zh_TW]=開啟新視窗
+Exec=firefox -new-window
+
+[Desktop Action new-private-window]
+Name=Open a New Private Window
+Name[ar]=افتح نافذة جديدة للتصفح الخاص
+Name[ca]=Obre una finestra nova en mode d'incògnit
+Name[cs]=Otevřít nové anonymní okno
+Name[de]=Ein neues privates Fenster öffnen
+Name[el]=Νέο ιδιωτικό παράθυρο
+Name[es]=Abrir una ventana privada nueva
+Name[fi]=Avaa uusi yksityinen ikkuna
+Name[fr]=Ouvrir une nouvelle fenêtre de navigation privée
+Name[he]=פתיחת חלון גלישה פרטית חדש
+Name[hu]=Új privát ablak nyitása
+Name[it]=Apri una nuova finestra anonima
+Name[nb]=Åpne et nytt privat vindu
+Name[ru]=Новое приватное окно
+Name[sl]=Odpri novo okno zasebnega brskanja
+Name[sv]=Öppna ett nytt privat fönster
+Name[tr]=Yeni gizli pencere aç
+Name[uk]=Відкрити нове вікно у потайливому режимі
+Name[zh_TW]=開啟新隱私瀏覽視窗
+Exec=firefox -private-window
+EOF
+cat << EOF > "$HOME/Desktop/codium.desktop"
+[Desktop Entry]
+Name=VSCodium
+Comment=Code Editing. Redefined.
+GenericName=Text Editor
+Exec=/usr/share/codium/codium --unity-launch %F
+Icon=vscodium
+Type=Application
+StartupNotify=false
+StartupWMClass=VSCodium
+Categories=TextEditor;Development;IDE;
+MimeType=text/plain;inode/directory;application/x-codium-workspace;
+Actions=new-empty-window;
+Keywords=vscode;
+
+[Desktop Action new-empty-window]
+Name=New Empty Window
+Exec=/usr/share/codium/codium --new-window %F
+Icon=vscodium
+EOF
+chown -R "$USER:$USER" "$HOME/Desktop"
+
+echo "============================================================================================"
+echo "Launched docker container."
+echo -e 'Open \e]8;;http://127.0.0.1:6080\e\\http://127.0.0.1:6080\e]8;;\e\\ via web browser.'
+echo ""
+echo "NOTE 1: Default user is \"$USER\", password is \"$PASSWORD\"."
+echo "NOTE 2: --security-opt seccomp=unconfined flag is required to launch Ubuntu Jammy/Noble based image on some environment."
+echo -e 'See \e]8;;https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e\\https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56\e]8;;\e\\'
+echo "============================================================================================"
+
+# clearup
+PASSWORD=
+VNC_PASSWORD=
+
+exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
## Summary
- add the ROS 2 Lyrical Docker image based on Ubuntu Resolute
- add Lyrical test/deploy workflows, bake target, Dependabot entry, and README docs
- update Lyrical TigerVNC startup handling for Ubuntu 26.04 and acknowledge atinfinity's reference implementation
- pin ros-apt-source for reproducible Docker builds and add a workflow to update the pinned version

<img width="1679" height="1141" alt="スクリーンショット 2026-06-04 13 11 39" src="https://github.com/user-attachments/assets/c5aa246b-d114-4f0a-ac1e-04b0d86a9d33" />

## Notes

The Quick Start command stays minimal; the optional `seccomp=unconfined` workaround is documented in `lyrical/entrypoint.sh` for older host environments.

The official ROS 2 installation docs resolve `ros-apt-source` from the latest GitHub release at install time. This Dockerfile pins the version for reproducible image builds, and `.github/workflows/update-ros-apt-source.yml` checks for updates monthly.

## Acknowledgement

Thanks to @atinfinity ( https://x.com/dandelion1124/status/2061799819744866815?s=20 )
<img width="619" height="543" alt="スクリーンショット 2026-06-04 13 37 02" src="https://github.com/user-attachments/assets/e81e99f5-10a8-4da3-a6c5-492836f31f3a" />
