### PR TITLE
docs: document seccomp workaround for GUI applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ docker run -p 6080:80 --shm-size=512m ghcr.io/tiryoh/ros2-desktop-vnc:lyrical
 
 Browse http://127.0.0.1:6080/.
 
+### Troubleshooting GUI applications
+
+Some GUI applications may not work correctly when their system calls are blocked by Docker's default seccomp profile. Reported symptoms include Gazebo displaying a blank window and VSCodium failing to launch. This may also occur with Docker Desktop on macOS.
+
+If you encounter these symptoms, retry with the seccomp profile disabled:
+
+```sh
+docker run -p 6080:80 --security-opt seccomp=unconfined --shm-size=512m ghcr.io/tiryoh/ros2-desktop-vnc:lyrical
+```
+
+> [!WARNING]
+> `seccomp=unconfined` disables Docker's default system call filtering and reduces container isolation. Update Docker Engine or Docker Desktop first, and use this workaround only when necessary with a trusted image.
+
+This workaround was originally introduced for an incompatibility between newer glibc in the container and older Docker seccomp implementations ([#56](https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/56)), and was later required to resolve GUI blackout issues ([#94](https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/94)).
+
 ![default desktop](https://github.com/user-attachments/assets/29ff479f-de54-4032-995d-d1be244ff4e7)
 
 ## Build


### PR DESCRIPTION
## Summary

- document `--security-opt seccomp=unconfined` as an optional troubleshooting step for GUI applications
- describe reported symptoms including blank Gazebo windows and VSCodium failing to launch on Docker Desktop for macOS
- keep the default Quick Start command confined and add an explicit warning about the reduced container isolation

## Background

The seccomp workaround was originally added for an incompatibility between newer glibc in the container and older Docker seccomp implementations (#56). It was later restored when GUI applications displayed blank windows (#94).

The option was removed from the Quick Start command when Lyrical support was added so that the default command would remain minimal (#267). Keeping that default is appropriate, but the workaround became difficult to discover when the container and VNC desktop started normally while an individual GUI application did not.

This change restores the information as troubleshooting guidance without enabling it by default.

## Validation

- `git diff --check origin/master...HEAD`
- confirmed that the branch changes only `README.md`
- documentation-only change; no runtime tests performed
