### PR TITLE
fix: Work around missing ros-gz metapackage on Rolling

### DIFF
--- a/rolling/Dockerfile
+++ b/rolling/Dockerfile
@@ -117,9 +117,15 @@ RUN apt-get update -q && \
 RUN rosdep update
 
 # Install simulation packages
+# The ros-rolling-ros-gz metapackage (and ros-gz-sim-demos) are currently missing
+# from packages.ros.org on noble, while the component packages remain available.
+# See: http://repo.ros2.org/status_page/rolling_default.html
 RUN apt-get update -q && \
     apt-get install -y \
-    ros-${ROS_DISTRO}-ros-gz && \
+    ros-${ROS_DISTRO}-ros-gz-bridge \
+    ros-${ROS_DISTRO}-ros-gz-image \
+    ros-${ROS_DISTRO}-ros-gz-interfaces \
+    ros-${ROS_DISTRO}-ros-gz-sim && \
     rm -rf /var/lib/apt/lists/*
 
 # Enable apt-get completion after running `apt-get update` in the container


### PR DESCRIPTION
## Summary
- This change targets the **Rolling** ROS 2 image (`rolling/Dockerfile`).
- Rolling CI has been failing with `Unable to locate package ros-rolling-ros-gz`.
- The `ros-rolling-ros-gz` metapackage (and `ros-gz-sim-demos`) are missing from `packages.ros.org` on noble, while component packages remain available.
- Install `ros-gz-bridge`, `ros-gz-image`, `ros-gz-interfaces`, and `ros-gz-sim` instead of the metapackage.

## Context
- Last successful Rolling scheduled build on `master` was around 2026-04-26.
- Status page: http://repo.ros2.org/status_page/rolling_default.html (`ros-rolling-ros-gz` marked missing).
- Unrelated to the recent GitHub Actions pinning work (#282).

## Test plan
- [ ] `Build and Test (Rolling)` passes for amd64 and arm64
- [ ] Confirm the simulation packages step installs without apt errors
- [ ] Other distro workflows remain unaffected (Rolling Dockerfile only)