### PR TITLE
docs: Add AGENTS.md with commit message conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,15 @@ uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
 ```
 
 Do not use floating refs such as `@v7`, `@main`, `@master`, or `@beta` for third-party Actions.
+
+## Dockerfile: ros-apt-source
+
+When a Dockerfile installs ROS via `ros-apt-source`, pin the version with `ARG ROS_APT_SOURCE_VERSION=...`.
+Do not resolve `releases/latest` at image build time.
+
+Updates are handled by `.github/workflows/update-ros-apt-source.yml` (monthly / manual).
+
+## README: seccomp workaround
+
+Do not add `--security-opt seccomp=unconfined` to the default Quick Start `docker run` command.
+Keep the troubleshooting explanation that documents when and why that option may be needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,13 +34,6 @@ ci: Pin GitHub Actions to patch versions
 docs: Add AGENTS.md with commit message conventions
 ```
 
-Avoid:
-
-```text
-fix(rolling): work around missing ros-gz metapackage
-chore(ci): add architecture detection
-```
-
 Exception: Dependabot may continue to generate titles such as `chore(deps): ...`. Do not rewrite those unless you are intentionally changing the Dependabot configuration.
 
 Pull request titles should follow the same format as commit subjects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+Guidance for coding agents working on this repository.
+
+## Project
+
+Docker images that provide ROS 2 Desktop environments accessible over VNC/noVNC.
+Each supported ROS distribution has its own directory (for example `humble/`, `jazzy/`, `rolling/`) with a `Dockerfile` and related files.
+CI builds and tests images via GitHub Actions under `.github/`.
+
+## Commit and pull request titles
+
+Use Conventional Commits **without a scope in parentheses**.
+
+Format:
+
+```text
+<type>: <Description>
+```
+
+Rules:
+
+- Use a short type such as `fix`, `feat`, `ci`, `docs`, `chore`, or `refactor`
+- Do **not** use scoped prefixes like `fix(rolling):` or `chore(ci):`
+- Put target area details in the description instead (for example `on Rolling`, `for GitHub Actions`)
+- Start the description with an uppercase letter
+- Keep the subject concise; put details in the commit body or PR description when needed
+
+Examples:
+
+```text
+fix: Work around missing ros-gz metapackage on Rolling
+ci: Pin GitHub Actions to patch versions
+docs: Add AGENTS.md with commit message conventions
+```
+
+Avoid:
+
+```text
+fix(rolling): work around missing ros-gz metapackage
+chore(ci): add architecture detection
+```
+
+Exception: Dependabot may continue to generate titles such as `chore(deps): ...`. Do not rewrite those unless you are intentionally changing the Dependabot configuration.
+
+Pull request titles should follow the same format as commit subjects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,5 @@
 # AGENTS.md
 
-Guidance for coding agents working on this repository.
-
-## Project
-
-Docker images that provide ROS 2 Desktop environments accessible over VNC/noVNC.
-Each supported ROS distribution has its own directory (for example `humble/`, `jazzy/`, `rolling/`) with a `Dockerfile` and related files.
-CI builds and tests images via GitHub Actions under `.github/`.
-
 ## Commit and pull request titles
 
 Use Conventional Commits **without a scope in parentheses**.
@@ -21,8 +13,7 @@ Format:
 Rules:
 
 - Use a short type such as `fix`, `feat`, `ci`, `docs`, `chore`, or `refactor`
-- Do **not** use scoped prefixes like `fix(rolling):` or `chore(ci):`
-- Put target area details in the description instead (for example `on Rolling`, `for GitHub Actions`)
+- Do **not** use scoped prefixes; put the target in the description instead
 - Start the description with an uppercase letter
 - Keep the subject concise; put details in the commit body or PR description when needed
 
@@ -34,6 +25,6 @@ ci: Pin GitHub Actions to patch versions
 docs: Add AGENTS.md with commit message conventions
 ```
 
-Exception: Dependabot may continue to generate titles such as `chore(deps): ...`. Do not rewrite those unless you are intentionally changing the Dependabot configuration.
+Exception: Dependabot may generate `chore(deps): ...` titles. Leave those unchanged unless intentionally changing Dependabot config.
 
-Pull request titles should follow the same format as commit subjects.
+Pull request titles follow the same format as commit subjects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,20 @@ docs: Add AGENTS.md with commit message conventions
 Exception: Dependabot may generate `chore(deps): ...` titles. Leave those unchanged unless intentionally changing Dependabot config.
 
 Pull request titles follow the same format as commit subjects.
+
+## GitHub Actions pins
+
+Pin third-party Actions to patch releases:
+
+```yaml
+uses: actions/checkout@v7.0.1
+```
+
+Exception: pin `aquasecurity/trivy-action` to a commit SHA, and keep the version in a comment:
+
+```yaml
+# aquasecurity/trivy-action@v0.36.0
+uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+```
+
+Do not use floating refs such as `@v7`, `@main`, `@master`, or `@beta` for third-party Actions.


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` for coding agents working on this repository.
- Document commit / PR title conventions: Conventional Commits without parenthesized scopes, and an uppercase letter after the colon.
- Note that Dependabot-generated `chore(deps): ...` titles are an exception.

## Test plan
- [ ] Review `AGENTS.md` wording for clarity
- [ ] Confirm examples match the intended style (`fix: ... on Rolling`, not `fix(rolling): ...`)


Made with [Cursor](https://cursor.com)